### PR TITLE
Add Fingerprint Module

### DIFF
--- a/lib/SphynxFingerprint/SphynxFinger.cpp
+++ b/lib/SphynxFingerprint/SphynxFinger.cpp
@@ -90,6 +90,36 @@ uint8_t SphynxFingerClass::createModel() {
     return status;
 }
 
+
+bool SphynxFingerClass::verifyFinger() {
+    finger.getTemplateCount();
+    Serial.print("Fingers enrolled: "); Serial.println(finger.templateCount);
+
+    status = finger.getImage();
+    if (status == FINGERPRINT_NOFINGER) {
+        return false;
+    }
+    else if (status != FINGERPRINT_OK) {
+        Serial.println("Falha ao ler a impressão digital");
+        return false;
+    }
+
+    status = finger.image2Tz();
+    if (status != FINGERPRINT_OK) {
+        Serial.println("Falha ao converter a imagem");
+        return false;
+    }
+
+    status = finger.fingerFastSearch();
+    if (status != FINGERPRINT_OK) {
+        Serial.println("Falha ao procurar a impressão digital");
+        return false;
+    }
+
+    Serial.println("Impressão digital encontrada");
+    return true;
+}
+
 uint8_t SphynxFingerClass::enrollFinger() {
     status = createModel();
     if (status != FINGERPRINT_OK) {

--- a/lib/SphynxFingerprint/SphynxFinger.cpp
+++ b/lib/SphynxFingerprint/SphynxFinger.cpp
@@ -32,6 +32,16 @@ void SphynxFingerClass::setupSensor() {
             }
         }
     }
+
+
+    finger.getParameters();
+    Serial.print("Fingerprint sensor Status Register:"); Serial.println(finger.status_reg);
+    Serial.print("Fingerprint sensor system id: "); Serial.println(finger.system_id);
+    Serial.print("Fingerprint sensor capacity: "); Serial.println(finger.capacity);
+    Serial.print("Fingerprint sensor security level: "); Serial.println(finger.security_level);
+    Serial.print("Fingerprint sensor device address: "); Serial.println(finger.device_addr);
+    Serial.print("Fingerprint sensor packet lenght: "); Serial.println(finger.packet_len);
+    Serial.print("Fingerprint sensor baud rate: "); Serial.println(finger.baud_rate);
 }
 
 uint8_t SphynxFingerClass::createModel() {

--- a/lib/SphynxFingerprint/SphynxFinger.cpp
+++ b/lib/SphynxFingerprint/SphynxFinger.cpp
@@ -1,0 +1,200 @@
+/*
+  SphynxFingerprint library for Sphynx: https://github.com/Cliyo/sphynx-esp32
+  will control the fingerprint sensor (sfm v1.7 and hlk-101) for the access control system.
+  uses uart2 for communication with the sensor.
+  tested with esp32-wroom-32
+  By: Snootic - 2024: https://github.com/snootic / @snootic_
+*/
+
+#include "SphynxFinger.h"
+
+int status;
+int length;
+
+bool sensorFound = false;
+
+SphynxFingerClass::SphynxFingerClass(){}
+
+void SphynxFingerClass::setupSensor() {
+    Serial2.begin(57600, SERIAL_8N1, TXD2, RXD2);
+
+    finger.begin(57600);
+    if (finger.verifyPassword()) {
+        Serial.println("Sensor encontrado");
+        sensorFound = true;
+    } else {
+        Serial.println("Sensor não encontrado");
+        for (int i = 0; i < 10; i++) {
+            delay(1000);
+            setupSensor();
+            if (sensorFound) {
+                break;
+            }
+        }
+    }
+}
+
+void SphynxFingerClass::readFinger(int &status) {
+    if (status == -1){
+        read(status);
+    }
+    else {
+        while (status != FINGERPRINT_NOFINGER) {
+            status = finger.getImage();
+            Serial.println("tira o dedo burrao");
+        }
+        read(status);
+    }
+
+}
+
+void SphynxFingerClass::read(int &status) {
+    while (status != FINGERPRINT_OK) {
+        status = finger.getImage();
+        switch (status) {
+            case FINGERPRINT_OK:
+                Serial.println("Imagem capturada");
+                break;
+            case FINGERPRINT_NOFINGER:
+                break;
+            case FINGERPRINT_PACKETRECIEVEERR:
+                Serial.println("Erro de comunicação");
+                break;
+            case FINGERPRINT_IMAGEFAIL:
+                Serial.println("Erro ao capturar imagem");
+                break;
+            default:
+                Serial.println("Erro desconhecido");
+                break;
+        }
+    }
+}
+
+uint8_t SphynxFingerClass::convertImage() {
+    status = finger.image2Tz(1);
+    switch (status) {
+        case FINGERPRINT_OK:
+            Serial.println("Imagem convertida");
+            return status;
+        case FINGERPRINT_IMAGEMESS:
+            Serial.println("Imagem muito desordenada");
+            return status;
+        case FINGERPRINT_PACKETRECIEVEERR:
+            Serial.println("Erro de comunicação");
+            return status;
+        case FINGERPRINT_FEATUREFAIL:
+            Serial.println("Não foi possível encontrar características da impressão digital");
+            return status;
+        case FINGERPRINT_INVALIDIMAGE:
+            Serial.println("Não foi possível encontrar características da impressão digital");
+            return status;
+        default:
+            Serial.println("Erro desconhecido");
+            return status;
+    }
+}
+
+uint8_t SphynxFingerClass::createModel() {
+    status = finger.createModel();
+    switch (status) {
+        case FINGERPRINT_OK:
+            Serial.println("Impressões digitais correspondentes!");
+            return status;
+        case FINGERPRINT_PACKETRECIEVEERR:
+            Serial.println("Erro de comunicação");
+            return status;
+        case FINGERPRINT_ENROLLMISMATCH:
+            Serial.println("As impressões digitais não correspondem");
+            return status;
+        default:
+            Serial.println("Erro desconhecido");
+            return status;
+    }
+}
+
+uint8_t SphynxFingerClass::enrollFinger() {
+    status = -1;
+    readFinger(status);
+    
+    delay(100);
+
+    Serial.println("Convertendo imagem");
+    convertImage();
+
+    delay(2000);
+
+    status = 0;
+    readFinger(status);
+
+    delay(100);
+    
+    Serial.println("Convertendo imagem");
+    convertImage();
+
+    delay(100);
+    
+    Serial.println("Criando modelo");
+    createModel();
+
+    finger.storeModel(1);
+
+    finger.loadModel(1);
+
+    finger.getModel();
+
+    //using the template from adafruit
+    uint8_t bytesReceived[534];
+    memset(bytesReceived, 0xff, 534);
+
+    uint32_t starttime = millis();
+    int i = 0;
+    while (i < 534 && (millis() - starttime) < 20000) {
+        if (Serial2.available()) {
+        bytesReceived[i++] = Serial2.read();
+        }
+    }
+    Serial.print(i); Serial.println(" bytes read.");
+    Serial.println("Decoding packet...");
+
+    uint8_t fingerTemplate[512];
+    memset(fingerTemplate, 0xff, 512);
+
+    int uindx = 9, index = 0;
+    memcpy(fingerTemplate + index, bytesReceived + uindx, 256);
+    uindx += 256;
+    uindx += 2;
+    uindx += 9;
+    index += 256;
+    memcpy(fingerTemplate + index, bytesReceived + uindx, 256);
+
+    for (int i = 0; i < 512; ++i) {
+        printHex(fingerTemplate[i], 2);
+    }
+
+    delay(2000);
+
+    clearUART2();
+
+    // finger.emptyDatabase();
+
+    return status;
+}
+
+void SphynxFingerClass::clearUART2() {
+    while (Serial2.available() > 0) {
+        Serial2.read();
+    }
+    Serial2.flush();
+}
+
+void SphynxFingerClass::printHex(int num, int precision) {
+  char tmp[16];
+  char format[128];
+
+  sprintf(format, "%%.%dX", precision);
+
+  sprintf(tmp, format, num);
+  Serial.print(tmp);
+}
+
+SphynxFingerClass SphynxFinger;

--- a/lib/SphynxFingerprint/SphynxFinger.h
+++ b/lib/SphynxFingerprint/SphynxFinger.h
@@ -18,14 +18,17 @@ class SphynxFingerClass {
     public:
         SphynxFingerClass();
         void setupSensor();
-        uint8_t enrollFinger();
-        void enrollFingerLocal();
-        bool verifyFinger();
+        uint8_t* enrollFinger();
+        boolean enrollFingerLocal(uint16_t id);
+        uint8_t* verifyFinger();
+        uint8_t verifyFinger(uint8_t id = 1);
         Adafruit_Fingerprint finger = Adafruit_Fingerprint(&Serial2);
+        boolean sensorFound = false;
     private:
         void printHex(int num, int precision);
         uint8_t createModel();
         void clearUART2();
+        uint8_t* generateTemplate();
 };
 
 extern SphynxFingerClass SphynxFinger;

--- a/lib/SphynxFingerprint/SphynxFinger.h
+++ b/lib/SphynxFingerprint/SphynxFinger.h
@@ -18,15 +18,12 @@ class SphynxFingerClass {
     public:
         SphynxFingerClass();
         void setupSensor();
-        void readFinger(int &status);
         uint8_t enrollFinger();
         void enrollFingerLocal();
         bool verifyFinger();
         Adafruit_Fingerprint finger = Adafruit_Fingerprint(&Serial2);
     private:
         void printHex(int num, int precision);
-        void read(int &status);
-        uint8_t convertImage();
         uint8_t createModel();
         void clearUART2();
 };

--- a/lib/SphynxFingerprint/SphynxFinger.h
+++ b/lib/SphynxFingerprint/SphynxFinger.h
@@ -1,0 +1,35 @@
+/*
+  SphynxFingerprint library for Sphynx: https://github.com/Cliyo/sphynx-esp32
+  will control the fingerprint sensor (sfm v1.7 and hlk-101) for the access control system.
+  uses uart2 for communication with the sensor.
+  tested with esp32-wroom-32
+  By: Snootic - 2024: https://github.com/snootic / @snootic_
+*/
+
+#ifndef SphynxFinger_h
+#define SphynxFinger_h
+
+#define TXD2 16
+#define RXD2 17
+
+#include <Adafruit_Fingerprint.h>
+
+class SphynxFingerClass {
+    public:
+        SphynxFingerClass();
+        void setupSensor();
+        void readFinger(int &status);
+        uint8_t enrollFinger();
+        void enrollFingerLocal();
+        bool verifyFinger();
+        Adafruit_Fingerprint finger = Adafruit_Fingerprint(&Serial2);
+    private:
+        void printHex(int num, int precision);
+        void read(int &status);
+        uint8_t convertImage();
+        uint8_t createModel();
+        void clearUART2();
+};
+
+extern SphynxFingerClass SphynxFinger;
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,17 +9,15 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32 @ 6.9.0
 board = esp32dev
 framework = arduino
 lib_ldf_mode = deep
-monitor_speed = 115200
+monitor_speed = 57600
 lib_compat_mode = strict
-lib_deps =
+lib_deps = 
 	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025
 	me-no-dev/ESP Async WebServer@^1.2.4
-	bblanchon/ArduinoJson@^7.0.4
 	miguelbalboa/MFRC522@^1.4.11
-	arduino-libraries/Arduino_JSON@^0.2.0
 	adafruit/Adafruit Fingerprint Sensor Library@^2.1.3
-	
+	bblanchon/ArduinoJson@^7.2.1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,7 +93,7 @@ void onWsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventT
   }
 }
 
-void apiRequest(String json, String method){
+void apiRequest(String json, String method, String subMethod){
   IPAddress api;
   HTTPClient http;
 
@@ -101,7 +101,7 @@ void apiRequest(String json, String method){
 
   Serial.println(api.toString());
 
-  String apiUrl = "http://" + api.toString() + ":57128/accessRegisters/" + method;
+  String apiUrl = "http://" + api.toString() + ":57128/"+ method + "/" + subMethod;
 
   Serial.println(apiUrl);
   http.begin(apiUrl);
@@ -133,7 +133,7 @@ void apiRequest(String json, String method){
 void apiRequestWithTag(String tag){
   String json = "{\"mac\":\""+SphynxWiFi.getMac()+"\",\"tag\":\""+tag+"\"}";
 
-  apiRequest(json, "tag");
+  apiRequest(json, "accessRegisters" ,"tag");
 }
 
 void apiRequestWithFingerTemplate(uint8_t* fingerTemplate){
@@ -152,7 +152,7 @@ void apiRequestWithFingerTemplate(uint8_t* fingerTemplate){
   String json;
   serializeJson(doc, json);
 
-  apiRequest(json, "fingerprint");
+  apiRequest(json, "accessRegisters","fingerprint");
 }
 
 void apiRequestWithFingerTemplate(uint16_t fingerID){
@@ -165,7 +165,7 @@ void apiRequestWithFingerTemplate(uint16_t fingerID){
   String json;
   serializeJson(doc, json);
 
-  apiRequest(json, "fingerprint");
+  apiRequest(json, "accessRegisters", "fingerprint");
 }
 
 void readFingerprint() {
@@ -225,6 +225,8 @@ void receiveTag(){
 
     Serial.println("Tag readed: " + id_cartao);
 
+    id_cartao = id_cartao.substring(1);
+
     if (currentMode == MODE_REGISTER_TAG) {
       ws.textAll(id_cartao);
       Serial.println("Tag registering completed");
@@ -249,6 +251,13 @@ void receiveTag(){
     rfid.PCD_StopCrypto1();
   }
   
+}
+
+void reverseFinder() {
+  String json = WiFi.localIP().toString() +","+ WiFi.macAddress();
+  
+  apiRequest(json, "deviceFinder", "push");
+
 }
 
 void sphynx(){
@@ -286,6 +295,8 @@ void setup(){
 }
 
 void loop(){
+  reverseFinder();
+
   if (SphynxFinger.sensorFound) {
     readFingerprint();
   }


### PR DESCRIPTION
This closes #2 by adding fingerprint handler. Tested with SFM v1.7 module, but sure it will work with other sensor models, just have to be sure to edit the Serial port number to match the sensor's. I will not finish the template enroll mode because it needs deeper research on how each sensor deals with the fingerprint images and data.

Additionally I added a reverseFinder method that will send the same data from UDP request to the API using HTTP POST, just in case the multicast doesnt work well (in fact the multicast isnt necessary anymore with this) . Anyway, It is working, but I will, in future, finish the template enrollment and then implement the image to the system altogether. Some optimizations can be made too, will work on it later.